### PR TITLE
RuntimeHost cannot be called multiple times

### DIFF
--- a/SSharp.Net/Runtime/RuntimeHost.cs
+++ b/SSharp.Net/Runtime/RuntimeHost.cs
@@ -64,6 +64,8 @@ namespace Scripting.SSharp.Runtime
     /// </summary>
     private static readonly object SyncRoot = new object();
 
+    public static bool IsInitialized { get; private set; }
+
     [Promote(false)]
     public static IScopeFactory ScopeFactory { get; private set; }
 
@@ -108,6 +110,8 @@ namespace Scripting.SSharp.Runtime
     [Promote(false)]
     public static void Initialize(Stream configuration)
     {
+      if (IsInitialized) return;
+
       Initialize(LoadConfiguration(configuration));
     }
 
@@ -118,6 +122,8 @@ namespace Scripting.SSharp.Runtime
     [Promote(false)]
     public static void Initialize(ScriptConfiguration configuration)
     {
+      if (IsInitialized) return;
+
       if (Parser == null)
       {
         Parser = new Parser.FastGrammar.LRParser();
@@ -158,6 +164,7 @@ namespace Scripting.SSharp.Runtime
       }
       finally
       {
+        IsInitialized = true;
         UnLock();
       }
     }
@@ -227,6 +234,7 @@ namespace Scripting.SSharp.Runtime
       }
       finally
       {
+        IsInitialized = false;
         UnLock();
       }
     }

--- a/UnitTests/Runtime.cs
+++ b/UnitTests/Runtime.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Scripting.SSharp.Runtime;
+using Scripting.SSharp.Runtime.Configuration;
 using Scripting.SSharp.Runtime.Promotion;
 using Scripting.SSharp;
 
@@ -29,6 +30,26 @@ namespace UnitTests
         configStream.Seek(0, SeekOrigin.Begin);
         return configStream;
       }
+    }
+
+    // Ensures runtime host does not crash if Initialize is called multiple times
+    [TestMethod]
+    public void ShouldAllowMultipleInitializes()
+    {
+      RuntimeHost.Initialize();
+      RuntimeHost.Initialize();
+      RuntimeHost.Initialize(TestConfig);
+      RuntimeHost.Initialize(new ScriptConfiguration());
+    }
+
+    [TestMethod]
+    public void ShouldChangeInitializationState()
+    {
+      Assert.IsFalse(RuntimeHost.IsInitialized);
+      RuntimeHost.Initialize();
+      Assert.IsTrue(RuntimeHost.IsInitialized);
+      RuntimeHost.CleanUp();
+      Assert.IsFalse(RuntimeHost.IsInitialized);
     }
 
     [TestMethod]


### PR DESCRIPTION
This commit fixes a crash related to calling RuntimeHost.Initialze multiple times
